### PR TITLE
Fix payments date and paid amount display

### DIFF
--- a/components/payments/CustomPaymentModal.tsx
+++ b/components/payments/CustomPaymentModal.tsx
@@ -131,11 +131,7 @@ export default function CustomPaymentModal({
       ? description.trim()
       : `${typeLabelMap[type] ?? type} по работе ${workName}`;
 
-    // Формируем дату с 00:00:00.000
-    const date = new Date(paymentDate);
-    date.setHours(0, 0, 0, 0);
-    const isoDate = date.toISOString();
-
+    // Отправляем просто дату YYYY-MM-DD
     onSubmit({
       userId: selectedUserId,
       workId: selectedWorkId,
@@ -144,8 +140,8 @@ export default function CustomPaymentModal({
       description: finalDescription,
       userName,
       workName,
-      paymentDate: isoDate,
-          currency,
+      paymentDate,
+      currency,
     });
   };
 

--- a/components/payments/WorkCard.tsx
+++ b/components/payments/WorkCard.tsx
@@ -34,7 +34,7 @@ export default function WorkCard({
 }: WorkCardProps) {
   const { formatRussian } = useDateManager();
   const accrued = typeof accruedOverride === 'number' ? accruedOverride : (work.totalAccrued ?? 0);
-  const paidForDisplay = Math.min(work.paidAmount || 0, accrued);
+  const paidForDisplay = work.paidAmount || 0;
   return (
     <div className="group">
       <Card className="bg-white border border-gray-200 hover:border-gray-300 transition-all duration-200 shadow-sm hover:shadow-md">


### PR DESCRIPTION
Asana:
Баг - отображается неверная информация на вкладке выплат
https://app.asana.com/1/1204459479204424/project/1210711311020546/task/1212340435996274?focus=true

**Проблема**
_paymentDate_ у нас по смыслу “дата (день)”, но иногда она приходила/обрабатывалась как _DateTime_ (момент времени). Дата могла “съехать” на предыдущий день и “сегодня” сохранялось как “вчера”.

**Решение**
Привели _paymentDate_ к единому виду “только день”: берём YYYY-MM-DD (если приходит ISO, отрезаем до YYYY-MM-DD) и сохраняем как 00:00:00 UTC через Date.UTC(year, month-1, day). Так paymentDate всегда остаётся одним и тем же календарным днём независимо от часового пояса.