### PR TITLE
Fix Payment History stale data and total amount not updating

### DIFF
--- a/app/payments/page.tsx
+++ b/app/payments/page.tsx
@@ -773,7 +773,7 @@ export default function PaymentsPage() {
         )}
 
         {activeTab === 'history' && (
-          <PaymentHistoryTab currentUserId={user?.id} />
+          <PaymentHistoryTab key={user?.id} currentUserId={user?.id} />
         )}
 
         {/* Модальные окна */}

--- a/components/payments/PaymentHistoryTab.tsx
+++ b/components/payments/PaymentHistoryTab.tsx
@@ -34,7 +34,7 @@ export default function PaymentHistoryTab({
     filters,
     setFilters,
     refetch,
-  } = usePaymentHistory();
+  } = usePaymentHistory(currentUserId);
 
   const [deletingPaymentId, setDeletingPaymentId] = useState<string | null>(
     null
@@ -77,6 +77,13 @@ export default function PaymentHistoryTab({
       }
     }
   };
+
+  // Force refetch on mount to ensure data is fresh, especially after mutations
+  // that might have occurred while this tab was inactive/unmounted
+  React.useEffect(() => {
+    refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Показываем ошибку только если она действительно есть и не связана с загрузкой
   if (error && !loading) {

--- a/hooks/usePaymentHistory.ts
+++ b/hooks/usePaymentHistory.ts
@@ -17,10 +17,11 @@ interface UsePaymentHistoryResult {
   refetch: () => void;
 }
 
-export function usePaymentHistory(): UsePaymentHistoryResult {
+export function usePaymentHistory(userId?: string): UsePaymentHistoryResult {
   const [filters, setFiltersState] = useState<PaymentHistoryDto>({
     page: 1,
     limit: 20,
+    viewerId: userId,
   });
 
   const {
@@ -29,7 +30,9 @@ export function usePaymentHistory(): UsePaymentHistoryResult {
     isFetching,
     error: queryError,
     refetch,
-  } = useGetPaymentHistoryQuery(filters);
+  } = useGetPaymentHistoryQuery(filters, {
+    refetchOnMountOrArgChange: true,
+  });
 
   const setFilters = useCallback((newFilters: Partial<PaymentHistoryDto>) => {
     setFiltersState((prev) => ({

--- a/types/payment.ts
+++ b/types/payment.ts
@@ -169,6 +169,7 @@ export interface PaymentHistoryDto {
   endDate?: string;
   page?: number;
   limit?: number;
+  viewerId?: string;
 }
 
 // create-payment-and-close


### PR DESCRIPTION
Asana:
Баг - не правильное отображение итоговой суммы (доделать)
https://app.asana.com/1/1204459479204424/project/1210711311020546/task/1212590177014164?focus=true

Проблема:
При переключении аккаунтов в «Истории платежей» показывалась сумма предыдущего пользователя. Обновлялась только после F5.

Причина:
Данные брались из кэша и не учитывали, что пользователь сменился.

Решение:
Сделали кэш уникальным для каждого пользователя и принудительно обновляем данные при смене аккаунта.

Результат:
Сумма «Всего получено» сразу отображается корректно без перезагрузки страницы.